### PR TITLE
Add util cost test

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "grunt-get-branchname": "^0.2.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/util.test.js"
   },
   "repository": {
     "type": "git",

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+const Util = require('../src/util');
+
+global.WORK = 'work';
+global.CARRY = 'carry';
+global.MOVE = 'move';
+
+global.BODYPART_COST = {
+  [WORK]: 100,
+  [CARRY]: 50,
+  [MOVE]: 50,
+};
+
+assert.strictEqual(Util.getCreepCost([WORK, CARRY, MOVE]), 200);
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- add util cost test for `getCreepCost`
- use Node to run the test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684175c21e5c83218e43921ba911bd13