### PR TITLE
Fix uninitialized Memory object

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,11 @@ const MainOp = require('./mainOp');
 const version = require('./version');
 const c = require('./constants');
 
+// Ensure global Memory object exists when running outside the Screeps engine
+if (typeof global.Memory === 'undefined' || global.Memory === null) {
+    global.Memory = {};
+}
+
 
 let debug = new DebugType;
 let mainOp = new MainOp;

--- a/src/mainOp.js
+++ b/src/mainOp.js
@@ -14,6 +14,12 @@ module.exports = class MainOp extends Operation {
         super();
         U.l('INIT MAIN');
 
+        // Ensure Memory object exists; Screeps may return `null` when memory is
+        // wiped or corrupted.
+        if (typeof Memory !== 'object' || Memory === null) {
+            global.Memory = {};
+        }
+
 
         for (let memObj in Memory) {
             switch (memObj) {


### PR DESCRIPTION
## Summary
- guard against undefined `Memory` in `MainOp` constructor so initialization works when Memory is cleared

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842d431a0788321b5c691ec39e5b628