### PR TITLE
Handle read-only Memory property when initializing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,8 +5,14 @@ const version = require('./version');
 const c = require('./constants');
 
 // Ensure global Memory object exists when running outside the Screeps engine
-if (typeof global.Memory === 'undefined' || global.Memory === null) {
-    global.Memory = {};
+// Some environments expose `Memory` as a read-only property on the global
+// object, which would throw when assigning to `global.Memory`. Guard against
+// this by only assigning when the property is writable or absent.
+{
+    const desc = Object.getOwnPropertyDescriptor(global, 'Memory');
+    if ((!desc || desc.writable) && (typeof global.Memory === 'undefined' || global.Memory === null)) {
+        global.Memory = {};
+    }
 }
 
 

--- a/src/mainOp.js
+++ b/src/mainOp.js
@@ -15,9 +15,13 @@ module.exports = class MainOp extends Operation {
         U.l('INIT MAIN');
 
         // Ensure Memory object exists; Screeps may return `null` when memory is
-        // wiped or corrupted.
-        if (typeof Memory !== 'object' || Memory === null) {
-            global.Memory = {};
+        // wiped or corrupted.  Avoid assigning to a read-only `Memory` property
+        // if it already exists in the environment.
+        {
+            const desc = Object.getOwnPropertyDescriptor(global, 'Memory');
+            if ((!desc || desc.writable) && (typeof Memory !== 'object' || Memory === null)) {
+                global.Memory = {};
+            }
         }
 
 


### PR DESCRIPTION
## Summary
- avoid assigning to a read-only `Memory` global in `main.js`
- do the same safeguard in `MainOp` constructor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842d67abb44832187e8226a0e235a5c