### PR TITLE
Fix Memory initialization on empty shards

### DIFF
--- a/src/mainOp.js
+++ b/src/mainOp.js
@@ -19,7 +19,7 @@ module.exports = class MainOp extends Operation {
         // if it already exists in the environment.
         {
             const desc = Object.getOwnPropertyDescriptor(global, 'Memory');
-            if ((!desc || desc.writable) && (typeof Memory !== 'object' || Memory === null)) {
+            if ((!desc || desc.writable || desc.set) && (typeof Memory !== 'object' || Memory === null)) {
                 global.Memory = {};
             }
         }


### PR DESCRIPTION
## Summary
- handle null Memory when running on a shard with no prior data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842d741ff5c8321a40a44b0db4202ba